### PR TITLE
Remove duplicate ghost_print_usage() declaration

### DIFF
--- a/ghost.c
+++ b/ghost.c
@@ -43,7 +43,6 @@ static void signal_handler(int signo);
 static void ghost_set_verbosity(int level);
 static void ghost_parse_args(int argc, char* arg[]);
 static void ghost_print_usage();
-static void ghost_print_usage();
 
 static void signal_handler(int signo) {
   s_signo = signo;


### PR DESCRIPTION
Closes https://github.com/ankushT369/GhostSSH/issues/13

This PR removes the redundant declaration of the `ghost_print_usage()` function in `ghost.c`. Having the same function declared multiple times can lead to unexpected behavior and makes the code harder to understand. Removing the duplicate declaration cleans up the codebase and improves maintainability.