### PR TITLE
Use configured SSH port for server connections

### DIFF
--- a/ghost-server.c
+++ b/ghost-server.c
@@ -25,7 +25,7 @@ void ghost_http_handler(struct mg_connection *http, int ev, void *ev_data) {
         }
     } else if (ev == MG_EV_WS_OPEN) {
         MG_INFO(("WebSocket connection is successfully established"));
-        create_local_url(TCP, SSH_PORT);
+        create_local_url(TCP, config.sshd_port);
         struct mg_connection *tcp = mg_connect(http->mgr,
                 url_buffer, ghost_tcp_handler, NULL);
 


### PR DESCRIPTION
Closes https://github.com/ankushT369/GhostSSH/issues/12

This change updates the server-side connection logic to utilize the `config.sshd_port` value instead of hardcoding port 22. This ensures the application respects the SSH port specified through the command-line interface and configuration file, resolving the configurability issue. The fix involves replacing direct references to `SSH_PORT` with the configured port value throughout the server connection process.